### PR TITLE
fix date picker background

### DIFF
--- a/lib/date-picker/date-picker-dialog.js
+++ b/lib/date-picker/date-picker-dialog.js
@@ -62,7 +62,8 @@ var DatePickerDialog = React.createClass({
       },
 
       dialogContent: {
-        width: this.props.mode === 'landscape' ? 560 : 280
+        width: this.props.mode === 'landscape' ? 560 : 280,
+        backgroundColor: 'white'
       },
 
       dialogBodyContent: {

--- a/src/date-picker/date-picker-dialog.jsx
+++ b/src/date-picker/date-picker-dialog.jsx
@@ -57,6 +57,7 @@ let DatePickerDialog = React.createClass({
 
       dialogContent: {
         width: this.props.mode === 'landscape' ? 560 : 280,
+        backgroundColor: 'white',
       },
 
       dialogBodyContent: {


### PR DESCRIPTION
Unfortunately, this component doesn't actually merge styles that are passed in. Doing this as a quick fix since we won't be adding to our usage of material UI going forward. For context, the some change in react 15 upgrade caused the background to go transparent. 