### PR TITLE
Add 1px of magic margin to fix 110% zoom bug, also fix cutoff text in Safari (at regular zoom)

### DIFF
--- a/lib/date-picker/calendar-month.js
+++ b/lib/date-picker/calendar-month.js
@@ -20,7 +20,7 @@ var CalendarMonth = React.createClass({
 
   render: function render() {
     var styles = {
-      lineHeight: '32px',
+      lineHeight: '30px',
       textAlign: 'center',
       padding: '8px 14px 0 14px'
     };

--- a/lib/date-picker/calendar.js
+++ b/lib/date-picker/calendar.js
@@ -106,8 +106,8 @@ var Calendar = React.createClass({
         opacity: '0.5',
         height: 12,
         fontWeight: '500',
-        margin: 0
-      },
+        margin: '1px 0 0 0' },
+      // 1px of top margin fixes the bug at 110% zoom
       weekTitleDay: {
         listStyle: 'none',
         float: 'left',

--- a/src/date-picker/calendar-month.jsx
+++ b/src/date-picker/calendar-month.jsx
@@ -18,7 +18,7 @@ let CalendarMonth = React.createClass({
 
   render() {
     let styles = {
-      lineHeight: '32px',
+      lineHeight: '30px',
       textAlign: 'center',
       padding: '8px 14px 0 14px',
     };

--- a/src/date-picker/calendar.jsx
+++ b/src/date-picker/calendar.jsx
@@ -107,7 +107,7 @@ let Calendar = React.createClass({
         opacity: '0.5',
         height: 12,
         fontWeight: '500',
-        margin: 0,
+        margin: '1px 0 0 0', // 1px of top margin fixes the bug at 110% zoom
       },
       weekTitleDay: {
         listStyle: 'none',


### PR DESCRIPTION
Tested in Chrome + FF + Safari + IE10.

Here's the safari issue:
Before:
![screen shot 2017-11-07 at 1 53 15 pm](https://user-images.githubusercontent.com/4596706/32520079-9e315952-c3c3-11e7-927c-8e9029a60cc1.png)
After:
![screen shot 2017-11-07 at 1 53 24 pm](https://user-images.githubusercontent.com/4596706/32520085-a17fcba2-c3c3-11e7-8daf-fc261498e7aa.png)
